### PR TITLE
Support for Consul 0.7 txn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: clojure
 before_script:
-  - wget 'https://releases.hashicorp.com/consul/0.5.2/consul_0.5.2_linux_amd64.zip'
-  - unzip "consul_0.5.2_linux_amd64.zip"
+  - wget 'https://releases.hashicorp.com/consul/0.7.0/consul_0.7.0_linux_amd64.zip'
+  - unzip "consul_0.7.0_linux_amd64.zip"
   - ./consul --version
 script:
   - ./consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul &

--- a/README.md
+++ b/README.md
@@ -139,6 +139,38 @@ Let's remove more than one:
 => #{}
 ```
 
+## Atomic transactions (available in Consul 0.7)
+
+The txn library allows executing multiple operations in an atomic transaction. All operations
+in the txn Consul 0.7 txn documentation are supported https://www.consul.io/docs/agent/http/kv.html
+
+The result of a transaction is always either a list of results, or an exception if the transaction
+was not successful.
+
+```clojure
+(require '[consul.txn :as txn])
+
+(txn/put :local (fn [tx] (txn/kv-set tx "key" "val")
+                         (txn/kv-get tx "key")))
+
+=> ({:create-index 3296,
+     :flags 0,
+     :key "key",
+     :lock-index 0,
+     :modify-index 3296,
+     :value nil}
+    {:create-index 3296,
+     :flags 0,
+     :key "key",
+     :lock-index 0,
+     :modify-index 3296,
+     :value "val"})
+```
+
+If any of the operations fail, the whole transaction fails. Errors are reported in the exception `:errors` key.
+
+Currently supported operations: `kv-set`, `kv-get`, `kv-set-cas`, `kv-lock`, `kv-unlock`, `kv-get-tree`, `kv-check-index`,
+`kv-check-session`, `kv-delete`, `kv-delete-tree`, `kv-delete-cas`.
 
 ### Agent
 

--- a/src/consul/txn.clj
+++ b/src/consul/txn.clj
@@ -1,0 +1,119 @@
+(ns consul.txn
+  (:require [consul.core :as core]))
+
+(defn- build-operation
+  "Create a map for a txn operation. Currently only :KV is supported."
+  [operation verb key params]
+  {operation (merge {:Verb verb :Key key} params)})
+
+(defn- build-params
+  "Create the request parameters."
+  [params]
+  (reduce-kv (fn [acc key val]
+               (cond
+                 (and (= key :stale) val)            (assoc acc :stale "")
+                 (and (= key :consistent) val)       (assoc acc :consistent "")
+                 (and (= key :stale) (not val))      (dissoc acc :stale)
+                 (and (= key :consistent) (not val)) (dissoc acc :consistent)
+                 (= key :string?)                    acc
+                 :else                               (assoc acc key val)))
+             {} params))
+
+(defn put
+  "Starts an atomic transaction. Available in Consul 0.7 and later.
+
+  Parameters:
+
+  :dc      - Optional data center in which to run the transaction, defaults agent's data center.
+  :token   - The ACL token
+  :string? - Converts the value returned into a string, if the result has a value."
+  ([conn f]
+   (put conn {} f))
+
+  ([conn {:keys [dc token stale consistent string?] :or {stale? false consistent? false string? true} :as params} f]
+   (let [operations (-> [] transient f persistent!)
+         response   (core/consul conn :put [:txn] {:body operations
+                                                   :query-params (build-params params)})]
+     (map (fn [result] (core/kv-map-convert (:KV result) string?))
+          (get-in response [:body :Results])))))
+
+(defn kv-set
+  "Sets the key to the given value"
+  [tx key value & {:keys [flags] :as optional}]
+  (let [base   {:Value (core/str->base64 value)}
+        params (if flags (assoc base :Flags flags) base)
+        op     (build-operation :KV "set" key params)]
+    (conj! tx op)))
+
+(defn kv-set-cas
+  "Sets the key ot the given value with check-and-set semantics.
+  The key will only be set if its current modify index matches the
+  supplied index"
+  [tx key value index & {:keys [flags] :as optional}]
+  (let [base   {:Value (core/str->base64 value)
+                :Index index}
+        params (if flags (assoc base :Flags flags) base)
+        op     (build-operation :KV "cas" key params)]
+    (conj! tx op)))
+
+(defn kv-lock
+  "Unlocks the key with the given Session. The key will only release
+  the lock if the session is valid and currently has it locked."
+  [tx key value session & {:keys [flags] :as optional}]
+  (let [base   {:Value (core/str->base64 value)
+                :Session session}
+        params (if flags (assoc base :Flags flags) base)
+        op     (build-operation :KV "lock" key params)]
+    (conj! tx op)))
+
+(defn kv-unlock
+  "Gets the key during the transaction. This fails the transaction if
+  the key doesn't exist. The key may not be present in the results if
+  ACLs do not permit it to be read."
+  [tx key value session & {:keys [flags] :as optional}]
+  (let [base   {:Value (core/str->base64 value)
+                :Session session}
+        params (if flags (assoc base :Flags flags) base)
+        op     (build-operation :KV "unlock" key params)]
+    (conj! tx op)))
+
+(defn kv-get
+  "Gets the key during the transaction. This fails the transaction if
+  the key doesn't exist. The key may not be present in the results if
+  ACLs do not permit it to be read."
+  [tx key]
+  (conj! tx (build-operation :KV "get" key nil)))
+
+(defn kv-get-tree
+  "Gets all keys with a prefix of key during the transaction. This does
+  not fail the transaction if the key doesn't exist. Not all keys may be
+  present in the results if ACLs do not permit them to be read."
+  [tx prefix]
+  (conj! tx (build-operation :KV "get-tree" prefix nil)))
+
+(defn kv-check-index
+  "Fails the transaction if key does not have a modify index equal to
+  supplied index."
+  [tx key index]
+  (conj! tx (build-operation :KV "check-index" key {:Index index})))
+
+(defn kv-check-session
+  "Fails the transaction if key is not currently locked by session."
+  [tx key session]
+  (conj! tx (build-operation :KV "check-session" key {:Session session})))
+
+(defn kv-delete
+  "Deletes the key."
+  [tx key]
+  (conj! tx (build-operation :KV "delete" key nil)))
+
+(defn kv-delete-tree
+  "Deletes all keys with a prefix of key."
+  [tx prefix]
+  (conj! tx (build-operation :KV "delete-tree" prefix nil)))
+
+(defn kv-delete-cas
+  "Deletes the key with check-and-set semantics. The key will only
+  be deleted if its current modify index matches the supplied index."
+  [tx key index]
+  (conj! tx (build-operation :KV "delete-cas" key {:Index index})))

--- a/test/consul/txn_test.clj
+++ b/test/consul/txn_test.clj
@@ -1,0 +1,129 @@
+(ns consul.txn-test
+  (:require [consul.txn :as txn]
+            [consul.core :as core]
+            [clojure.test :refer :all])
+  (:import (java.util UUID)))
+
+(defn clean []
+  (core/kv-del :local "consul-clojure" {:recurse? true})
+  (doseq [service-id (filter #(re-seq #"^consul-clojure.*" %) (keys (core/agent-services :local)))]
+    (core/agent-deregister-service :local service-id)))
+
+(defn cleanup [f]
+  (clean)
+  (f)
+  (clean))
+
+(use-fixtures :each cleanup)
+
+(defn create-key [key] (str "consul-clojure." key))
+
+(deftest ^{:integration true} kv-get-set-test
+  (testing "basic get/set operations"
+    (let [results    (txn/put :local (fn [tx]
+                                       (txn/kv-set tx (create-key "key") "value")
+                                       (txn/kv-get tx (create-key "key"))))
+          set-result (first results)
+          get-result (last results)]
+      (is (= 2 (count results)))
+      (is (= (:create-index set-result) (:create-index get-result)))
+      (is (= (:flags set-result) (:flags get-result)))
+      (is (= "consul-clojure.key" (:key set-result) (:key get-result)))
+      (is (= (:lock-index set-result) (:lock-index get-result)))
+      (is (= (:modify-index set-result) (:modify-index get-result)))
+      (is (nil? (:value set-result)))
+      (is (= "value" (:value get-result))))
+
+    (let [result (first (txn/put :local (fn [tx] (txn/kv-set tx (create-key "key") "value" :flags 10))))]
+      (is (= 10 (:flags result))))))
+
+(deftest ^{:integration true} kv-cas-test
+  (testing "check-and-set semantics with the correct index"
+    (let [index  (-> (txn/put :local (fn [tx] (txn/kv-set tx (create-key "key") "value"))) first :modify-index)
+          result (-> (txn/put :local (fn [tx] (txn/kv-set-cas tx (create-key "key") "value" index))) first)]
+      (is (integer? (:lock-index result)))
+      (is (= "consul-clojure.key" (:key result)))
+      (is (= 0 (:flags result)))
+      (is (nil? (:value result)))
+      (is (integer? (:create-index result)))
+      (is (integer? (:modify-index result)))
+      (is (not (= index (:modify-index result))))
+      (is (thrown-with-msg? Exception #"Transaction failure"
+                            (txn/put :local (fn [tx] (txn/kv-set-cas tx (create-key "key") "value" (- index 1)))))))))
+
+(deftest ^{:integration true} kv-lock-unlock-test
+  (testing "locking and unlocking with a session"
+    (let [session-key   (core/session-create :local)
+          results       (txn/put :local (fn [tx]
+                                          (txn/kv-lock tx (create-key "key") "value" session-key)
+                                          (txn/kv-unlock tx (create-key "key") "value" session-key)))
+          lock-result   (first results)
+          unlock-result (last results)]
+      (is (= (:lock-index lock-result) (:lock-index unlock-result)))
+      (is (= "consul-clojure.key" (:key lock-result) (:key unlock-result)))
+      (is (= (:flags lock-result) (:flags unlock-result)))
+      (is (= nil (:value lock-result) (:value unlock-result)))
+      (is (= (:create-index lock-result) (:create-index unlock-result)))
+      (is (= (:modify-index lock-result) (:modify-index unlock-result)))
+      (is (thrown-with-msg? Exception #"Transaction failure"
+                            (txn/put :local (fn [tx] (txn/kv-lock tx (create-key "key") "value" "not-uuid")))))
+      (is (thrown-with-msg? Exception #"Transaction failure"
+                            (txn/put :local (fn [tx] (txn/kv-lock tx (create-key "key") "value" (str (UUID/randomUUID))))))))))
+
+(deftest ^{:integration true} kv-get-tree-test
+  (testing "getting all items with a prefix"
+    (do (core/kv-put :local (create-key "prefix/key1") "value")
+        (core/kv-put :local (create-key "prefix/key2") "value")
+        (core/kv-put :local (create-key "other/key3") "value"))
+    (let [results (txn/put :local (fn [tx] (txn/kv-get-tree tx (create-key "prefix/"))))]
+      (is (= 2 (count results)))
+      (is (= "consul-clojure.prefix/key1" (:key (first results))))
+      (is (= "consul-clojure.prefix/key2" (:key (last results)))))))
+
+(deftest ^{:integration true} kv-check-index-test
+  (testing "checking the index"
+    (let [index (:modify-index (first (txn/put :local (fn [tx] (txn/kv-set tx (create-key "key") "val")))))
+          result (first (txn/put :local (fn [tx] (txn/kv-check-index tx (create-key "key") index))))]
+      (is (= index (:modify-index result)))
+      (is (thrown-with-msg? Exception #"Transaction failure"
+                            (txn/put :local (fn [tx] (txn/kv-check-index tx (create-key "key") (+ 1 index)))))))))
+
+(deftest ^{:integration true} kv-check-session-test
+  (testing "checking if the key is locked by a session"
+    (let [session-key (core/session-create :local)
+          results (txn/put :local (fn [tx]
+                                    (txn/kv-lock tx (create-key "key") "value" session-key)
+                                    (txn/kv-check-session tx (create-key "key") session-key)))]
+      (is (= 2 (count results)))
+      (is (thrown-with-msg? Exception #"Transaction failure"
+                            (txn/put :local (fn [tx] (txn/kv-check-session tx (create-key "key") (str (UUID/randomUUID))))))))))
+
+(deftest ^{:integration true} kv-delete-test
+  (testing "deletion of a key"
+    (let [key (create-key "key")]
+      (core/kv-put :local key "val")
+      (let [del-result (txn/put :local (fn [tx] (txn/kv-delete tx key)))]
+        (is (= 0 (count del-result)))
+        (is (nil? (:value (core/kv-get :local key))))))))
+
+(deftest ^{:integration true} kv-delete-tree-test
+  (testing "deletion of multiple keys in a tree"
+    (core/kv-put :local (create-key "prefix/key1") "val")
+    (core/kv-put :local (create-key "prefix/key2") "val")
+    (core/kv-put :local (create-key "other/key3") "val")
+    (let [del-result (txn/put :local (fn [tx] (txn/kv-delete-tree tx (create-key "prefix/"))))]
+      (is (= 0 (count del-result)))
+      (is (nil? (:value (core/kv-get :local (create-key "prefix/key1")))))
+      (is (nil? (:value (core/kv-get :local (create-key "prefix/key2")))))
+      (is (= "val" (:value (core/kv-get :local (create-key "other/key3"))))))))
+
+(deftest ^{:integration true} kv-delete-cas-test
+  (testing "deletion of a key with a specified index"
+    (let [index  (-> (txn/put :local (fn [tx] (txn/kv-set tx (create-key "key") "value"))) first :modify-index)
+          result (-> (txn/put :local (fn [tx] (txn/kv-delete-cas tx (create-key "key") index))) first)]
+      (is (= 0 (count result)))
+      (is (nil? (:value (core/kv-get :local (create-key "key"))))))
+    (let [index  (-> (txn/put :local (fn [tx] (txn/kv-set tx (create-key "key") "value"))) first :modify-index)]
+      (is (thrown-with-msg? Exception #"Transaction failure"
+                            (-> (txn/put :local (fn [tx] (txn/kv-delete-cas tx (create-key "key") (+ 1 index)))) first))))))
+


### PR DESCRIPTION
Adds a feature for Consul 0.7 KV transactions. A new namespace `txn`
with functions `txn/put` for building and executing a transaction and
`kv-*` in the same namespace providing support for all operations
available in the current Consul version.
