### PR TITLE
Enforce UTF8 when storing data.

### DIFF
--- a/src/consul/core.clj
+++ b/src/consul/core.clj
@@ -13,7 +13,7 @@
   (String. (DatatypeConverter/parseBase64Binary s) "UTF8"))
 
 (defn str->base64 [^String s]
-  (DatatypeConverter/printBase64Binary (.getBytes s)))
+  (DatatypeConverter/printBase64Binary (.getBytes s "UTF8")))
 
 (defn endpoint->path
   "Converts a vector into the consul endpoint path."


### PR DESCRIPTION
If we load consul data as UTF8, we should also enforce the charset when
storing data. Java's `.getBytes()` is using the system charset by
default, which might not be what we want.

Now for a weird reason our production servers unicode was broken and
this seems to fix our issues...