### PR TITLE
Ttl check fix

### DIFF
--- a/src/consul/core.clj
+++ b/src/consul/core.clj
@@ -310,7 +310,7 @@
   "Simple validation outlined in https://www.consul.io/docs/agent/checks.html."
   [{:keys [Name HTTP TTL Script Interval] :as check}]
   (and (string? Name)
-       (or (string? Script) (string? HTTP) (string? :TTL))
+       (or (string? Script) (string? HTTP) (string? TTL))
        (if (or Script HTTP)
          (string? Interval)
          true)))

--- a/test/consul/core_test.clj
+++ b/test/consul/core_test.clj
@@ -39,7 +39,8 @@
     (is (= (:Name (map->check m)) "Google"))
     (is (= (:HTTP (map->check m)) "http://www.google.com"))
     (is (= (:Interval (map->check m)) "10s"))
-    (is (= (:ServiceID (map->check (assoc m :service-id "redis-01"))) "redis-01"))))
+    (is (= (:ServiceID (map->check (assoc m :service-id "redis-01"))) "redis-01"))
+    (is (= (:TTL (map->check (-> m (dissoc :http :interval) (assoc :ttl "20s")))) "20s"))))
 
 (deftest ^{:integration true} consul-test
   (testing "with a connection failure"


### PR DESCRIPTION
Because the check was using `(string? :TTL)` the 'or' clause would always return false when Script and HTTP are nil, because `:TTL` is a keyword, not a string.

Made the code use a symbol instead of the keyword and added a unit test.